### PR TITLE
feat: support future dates and custom now text. Fixes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,16 @@ import TimeAgo from "react-timeago-i18n";
 
 ## Props
 
-| Property        | Description                                                                                                                                                          | Default Value        |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
-| `date`          | `string` or `Date`                                                                                                                                                   | -                    |
-| `locale`        | the language to use                                                                                                                                                  | `navigator.language` |
-| `formatOptions` | [options for `Intl.RelativeTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat#basic_format_usage) | `undefined`          |
-| `hideSeconds`   | By default, values smaller than 1 minute will shown as "1 minute" instead of frequently updating seconds, unless you set this property to `false`.                   | `true`               |
-| `roundStrategy` | By default, values are `rounded`ed (e.g. 11.9 months becomes "2 years"). If this is not desired, the rounding strategy can be changed to `floor`.                    | `"round"`            |
-| `timeElement`   | By default, the result is wrapped in `<time title="..."> ... </time>`, unless you set this property to `false`                                                       | `true`               |
+| Property          | Description                                                                                                                                                          | Default Value        |
+|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------|
+| `date`            | `string` or `Date`                                                                                                                                                   | -                    |
+| `locale`          | the language to use                                                                                                                                                  | `navigator.language` |
+| `formatOptions`   | [options for `Intl.RelativeTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat#basic_format_usage) | `undefined`          |
+| `allowFuture`     | By default, only dates in the _past_ are supported. If you want to display future dates (i.e. "in 3 days") set this property to `true`                               | `false`              |
+| `hideSeconds`     | By default, values smaller than 1 minute will shown as "1 minute" instead of frequently updating seconds, unless you set this property to `false`.                   | `true`               |
+| `hideSecondsText` | When using `hideSeconds`, seconds are displayed as "1 minute ago" or "in 1 minute", use this property to provide custom strings i.e. `["just now", "right now"]`     | `[]`                 |
+| `roundStrategy`   | By default, values are `round`ed (e.g. 11.9 months becomes "2 years"). If this is not desired, the rounding strategy can be changed to `floor`.                      | `"round"`            |
+| `timeElement`     | By default, the result is wrapped in `<time title="..."> ... </time>`, unless you set this property to `false`                                                       | `true`               |
 
 ## Context Provider
 

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -71,6 +71,90 @@ describe("TimeAgo", () => {
     });
   });
 
+  describe("hideSecondsText", () => {
+    it.each`
+      date                      | output
+      ${"2023-06-08"}           | ${"just now"}
+      ${"2023-06-06T11:01:59Z"} | ${"just now"}
+      ${"2023-06-06T11:01:01Z"} | ${"just now"}
+      ${"2023-06-06T11:00:59Z"} | ${"just now"}
+      ${"2023-06-06T11:00:01Z"} | ${"just now"}
+      ${"2023-06-06T11:00:00Z"} | ${"just now"}
+      ${"2023-06-06T10:59:59Z"} | ${"just now"}
+      ${"2023-06-06T10:59:58Z"} | ${"just now"}
+      ${"2023-06-06T10:59:01Z"} | ${"1 minute ago"}
+      ${"2023-06-06T10:59:00Z"} | ${"1 minute ago"}
+      ${"2023-06-06T10:58:59Z"} | ${"1 minute ago"}
+    `("renders $date as $output", ({ date, output }) => {
+      const div = setup({
+        date,
+        hideSeconds: true,
+        hideSecondsText: ["just now", "right now"],
+      });
+
+      expect(div).toHaveTextContent(output);
+    });
+
+    it.each`
+      date                      | output
+      ${"2023-06-08"}           | ${"in 2 days"}
+      ${"2023-06-06T11:01:59Z"} | ${"in 2 minutes"}
+      ${"2023-06-06T11:01:01Z"} | ${"in 1 minute"}
+      ${"2023-06-06T11:00:59Z"} | ${"in 1 minute"}
+      ${"2023-06-06T11:00:01Z"} | ${"right now"}
+      ${"2023-06-06T11:00:00Z"} | ${"just now"}
+      ${"2023-06-06T10:59:59Z"} | ${"just now"}
+      ${"2023-06-06T10:59:58Z"} | ${"just now"}
+      ${"2023-06-06T10:59:01Z"} | ${"1 minute ago"}
+      ${"2023-06-06T10:59:00Z"} | ${"1 minute ago"}
+      ${"2023-06-06T10:58:59Z"} | ${"1 minute ago"}
+    `(
+      "renders $date as $output if `allowFuture` is true",
+      ({ date, output }) => {
+        const div = setup({
+          date,
+          hideSeconds: true,
+          hideSecondsText: ["just now", "right now"],
+          allowFuture: true,
+        });
+
+        expect(div).toHaveTextContent(output);
+      }
+    );
+  });
+
+  describe("allowFuture", () => {
+    it.each`
+      date                      | output
+      ${"2023-06-06T11:01:00Z"} | ${"in 1 minute"}
+      ${"2023-06-06T11:59:00Z"} | ${"in 1 hour"}
+      ${"2023-06-06T23:00:00Z"} | ${"tomorrow"}
+      ${"2023-07-05"}           | ${"next month"}
+      ${"2027-05-06"}           | ${"in 4 years"}
+    `("renders $date as $output", ({ date, output }) => {
+      const div = setup({ date, allowFuture: true });
+
+      expect(div).toHaveTextContent(output);
+    });
+
+    it.each`
+      date                      | output
+      ${"2023-06-06T11:00:59Z"} | ${"in 1 minute"}
+      ${"2023-06-06T11:01:00Z"} | ${"in 1 minute"}
+      ${"2023-06-06T11:59:00Z"} | ${"in 59 minutes"}
+      ${"2023-06-06T23:00:00Z"} | ${"in 12 hours"}
+      ${"2023-07-05"}           | ${"in 28 days"}
+      ${"2027-05-06"}           | ${"in 3 years"}
+    `(
+      "renders future $date as $output using `roundStrategy` floor",
+      ({ date, output }) => {
+        const div = setup({ date, allowFuture: true, roundStrategy: "floor" });
+
+        expect(div).toHaveTextContent(output);
+      }
+    );
+  });
+
   describe("roundStrategy", () => {
     it.each`
       date                   | roundStrategy | output
@@ -81,7 +165,7 @@ describe("TimeAgo", () => {
       ${"2023-06-06T07:00Z"} | ${"floor"}    | ${"vor 4 Stunden"}
       ${"2023-06-06T07:00Z"} | ${"round"}    | ${"vor 4 Stunden"}
     `(
-      "renders $date as $output using $roundStrategy",
+      "renders $date as $output using `roundStrategy` $roundStrategy",
       async ({ date, roundStrategy, output }) => {
         const div = setup({ date, locale: "de-AT", roundStrategy });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ const TimeAgo = memo<TimeAgoProps>(
       formatOptions,
       allowFuture = false,
       hideSeconds = true,
-      hideSecondsText = [],
+      hideSecondsText: [pastSecondsText, futureSecondsText] = [],
       roundStrategy = "round",
       timeElement = true,
     } = {
@@ -138,13 +138,12 @@ const TimeAgo = memo<TimeAgoProps>(
           return formatter.format(-value, newUnit);
         }
 
-        const [past, future] = hideSecondsText;
         if (value < 0) {
-          return future ?? formatter.format(1, "minute");
+          return futureSecondsText ?? formatter.format(1, "minute");
         }
-        return past ?? formatter.format(-1, "minute");
+        return pastSecondsText ?? formatter.format(-1, "minute");
       },
-      [formatter, hideSeconds, hideSecondsText]
+      [formatter, hideSeconds, pastSecondsText, futureSecondsText]
     );
 
     const doUpdate = useCallback(() => {


### PR DESCRIPTION
Added additional props `allowFuture` and `hideSecondsText` (naming these was difficult, you may wish to rename them)

## `allowFuture`

If `true` allows a timeago to be a future date, will display values such as "in 1 hour"/"tomorrow"/"in 3 years"

I had to do a bit of `Math.abs` magic here to make `roundStrategy` work correctly because apparently `Math.floor(-0.1) === -1`, which ended up displaying "in 1 year" for near future dates.

## `hideSecondsText`

Here we provide custom text as `[pastString, futureString]`, to render instead of "1 minute ago"/"in 1 minute", when there is less than a minute.