### PR TITLE
avoid screen flickering by setting initial text before first render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Use a TypeScript namespace for all type defintions
+- Performance improvements
 
 ## 2.2.1 (2024-06-19)
 

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -224,7 +224,7 @@ describe("TimeAgo", () => {
       expect(screen.getByRole("main")).toHaveTextContent("5 months ago");
 
       // once only - useEffects did not trigger another render
-      expect(ref.current?.renderCount.current).toBe(2); // TODO: reduce by 1
+      expect(ref.current?.renderCount.current).toBe(1);
     });
 
     it("re-renders as time progresses, using minimal re-renders", async () => {
@@ -234,21 +234,21 @@ describe("TimeAgo", () => {
       });
       expect(screen.getByRole("main")).toHaveTextContent("now");
       // only 1 render during the initialisation phase
-      expect(ref.current?.renderCount.current).toBe(2); // TODO: reduce by 1
+      expect(ref.current?.renderCount.current).toBe(1);
 
       // jump forward 1 second
       await vi.advanceTimersByTimeAsync(1000);
 
       expect(screen.getByRole("main")).toHaveTextContent("1 second ago");
       // 1 new render
-      expect(ref.current?.renderCount.current).toBe(3); // TODO: reduce by 1
+      expect(ref.current?.renderCount.current).toBe(2);
 
       // jump forward 5 seconds
       await vi.advanceTimersByTimeAsync(5000);
 
       expect(screen.getByRole("main")).toHaveTextContent("6 seconds ago");
       // 5 new renders
-      expect(ref.current?.renderCount.current).toBe(8); // TODO: reduce by 1
+      expect(ref.current?.renderCount.current).toBe(7);
     });
 
     it("does not re-render if the date is unchanged", async () => {
@@ -258,28 +258,28 @@ describe("TimeAgo", () => {
       });
       expect(screen.getByRole("main")).toHaveTextContent("4 years ago");
       // only 1 render during the initialisation phase
-      expect(ref.current?.renderCount.current).toBe(2); // TODO: reduce by 1
+      expect(ref.current?.renderCount.current).toBe(1);
 
       // jump forward 1 second
       await vi.advanceTimersByTimeAsync(1000);
 
       expect(screen.getByRole("main")).toHaveTextContent("4 years ago");
       // 1 new render, unclear why
-      expect(ref.current?.renderCount.current).toBe(3); // TODO: reduce by 1
+      expect(ref.current?.renderCount.current).toBe(1);
 
       // jump forward 5 seconds
       await vi.advanceTimersByTimeAsync(5000);
 
       expect(screen.getByRole("main")).toHaveTextContent("4 years ago");
       // no new renders
-      expect(ref.current?.renderCount.current).toBe(3); // TODO: reduce by 1
+      expect(ref.current?.renderCount.current).toBe(1);
 
       // jump forward 10 seconds
       await vi.advanceTimersByTimeAsync(10_000);
 
       expect(screen.getByRole("main")).toHaveTextContent("4 years ago");
       // no new renders
-      expect(ref.current?.renderCount.current).toBe(3); // TODO: reduce by 1
+      expect(ref.current?.renderCount.current).toBe(1);
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,9 +135,6 @@ const TimeAgo = memo(
       ...props,
     };
 
-    const [text, setText] = useState("");
-    const [unit, setUnit] = useState<Unit>();
-
     const formatter = useMemo(
       () =>
         new Intl.RelativeTimeFormat(locale, {
@@ -168,18 +165,28 @@ const TimeAgo = memo(
       [formatter, hideSeconds, pastSecondsText, futureSecondsText]
     );
 
-    const doUpdate = useCallback(() => {
+    const getValues = useCallback(() => {
       const [value, newUnit] = timeSince(
         dateObject,
         roundStrategy,
         allowFuture
       );
-      setText(formatDate(value, newUnit));
-      setUnit(newUnit);
+      return {
+        text: formatDate(value, newUnit),
+        unit: newUnit,
+      };
+    }, [dateObject, roundStrategy, allowFuture, formatDate]);
+
+    const [text, setText] = useState<string>(() => getValues().text);
+    const [unit, setUnit] = useState<Unit>(() => getValues().unit);
+
+    const doUpdate = useCallback(() => {
+      setText(getValues().text);
+      setUnit(getValues().unit);
       // setUnit is auto-batched with the previous setState,
       // in react 18+, and auto-aborted if this would be a
       // no-op in all react versions.
-    }, [dateObject, roundStrategy, allowFuture, formatDate]);
+    }, [getValues]);
 
     useEffect(doUpdate, [doUpdate]);
 


### PR DESCRIPTION
Thanks for this library!

Right now this component has an layout flickering as on the first render the text is `""` and only after the first render `setText` is called.

This patch sets the text to the correct value before the first render.